### PR TITLE
Add <html></html> to index and generated output

### DIFF
--- a/generate_page.sh
+++ b/generate_page.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ##
-## pregeneratehtml.sh
+## generate_page.sh
 ##
 ## Made by gaspar_d
 ## Login   <d.gasparina@gmail.com>
@@ -45,6 +45,7 @@ main() {
   done
 
   echo "</body>"
+  echo "</html>"
 }
 
 

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<html>
 <head>
   <title>dstat</title>
   <link rel="stylesheet" type="text/css" href="css/nv.d3.min.css" />
@@ -83,3 +84,4 @@
   </div>
 
 </body>
+</html>


### PR DESCRIPTION
We have been finding the generated html of our logs
to be very useful.  We generate them after one of our
CI jobs that deploy an OpenStack cloud using RDO.
RDO is a community of people using and deploying
OpenStack on CentOS, Fedora, and RHEL. [1]

Our artifact server keeps our logs and artifacts
compressed, and upon access decompresses, parses,
and renders them in a browser.  In the case of the
html files generated by generate_page.sh, since the
the open/close html tags are not present it does not
set the MIME type correctly and we don't render correctly.

An example of this is here: [2]

[1] https://www.rdoproject.org/
[2] https://thirdparty-logs.rdoproject.org/jenkins-tripleo-quickstart-periodic-newton-delorean-ha_192gb-17/undercloud/var/log/extra/dstat.html.gz