### PR TITLE
use d3.range instead of homebrew range

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -192,7 +192,7 @@ function processCSV(csv, filename) {
       }
     } /* Use sequence for xAxis */
   } else {
-      xValues = Array.apply(null, Array(nlines)).map(function (_, i) {return i;});
+      xValues = d3.range(nlines);
       graphs.xAxis = function (xa) {
         xa.axisLabel('').tickFormat(function(d) {
             return d3.format('d')(d);


### PR DESCRIPTION
I tried the website with a dstat csv file of 18.3 MB, 
line js/dashboard.js:195 crashed with a stack overflow error.
Changed it with `d3.range`, test passed.